### PR TITLE
:redir END が必ず実行されるようにしました

### DIFF
--- a/autoload/quickrun.vim
+++ b/autoload/quickrun.vim
@@ -1040,11 +1040,14 @@ endfunction
 function! quickrun#execute(...)  " {{{2
   " XXX: Can't get a result if a:cmd contains :redir command.
   let result = ''
-  redir => result
-  for cmd in a:000
-    silent execute cmd
-  endfor
-  redir END
+  try
+    redir => result
+    for cmd in a:000
+      silent execute cmd
+    endfor
+  finally
+    redir END
+  endtry
   return result
 endfunction
 


### PR DESCRIPTION
`:redir END`が実行されず、次のquickrun実行時、または別のプラグインで...などまったく意図しないところで:redirを使った瞬間にエラーが出ます。

このVim scriptのヘボさはなんとかしてくれませんかね...
というか自分の他のプラグインでも同じような問題がありそう...
