### PR TITLE
added Redcarpet support for Markdown

### DIFF
--- a/autoload/quickrun.vim
+++ b/autoload/quickrun.vim
@@ -182,12 +182,16 @@ let g:quickrun#default_config = {
 \ 'lua': {},
 \ 'markdown': {
 \   'type': executable('Markdown.pl') ? 'markdown/Markdown.pl':
+\           executable('redcarpet') ? 'markdown/redcarpet':
 \           executable('kramdown') ? 'markdown/kramdown':
 \           executable('bluecloth') ? 'markdown/bluecloth':
 \           executable('pandoc') ? 'markdown/pandoc': '',
 \ },
 \ 'markdown/Markdown.pl': {
 \   'command': 'Markdown.pl',
+\ },
+\ 'markdown/redcarpet': {
+\   'command': 'redcarpet',
 \ },
 \ 'markdown/bluecloth': {
 \   'command': 'bluecloth',


### PR DESCRIPTION
Redcarpet is the most modern markdown parser on ruby,
and it has been used on github.
https://github.com/blog/832-rolling-out-the-redcarpet

取り込んでいただけると嬉しいです。
