### PR TITLE
add output_filetype to config

### DIFF
--- a/autoload/quickrun.vim
+++ b/autoload/quickrun.vim
@@ -33,6 +33,7 @@ let g:quickrun#default_config = {
 \   'exec': '%c %o %s %a',
 \   'eval': 0,
 \   'eval_template': '%s',
+\   'output_filetype': 'quickrun',
 \ },
 \ 'awk': {
 \   'exec': '%c %o -f %s %a',
@@ -1008,6 +1009,9 @@ function! s:normalize(config)
 
   for opt in ['cmdopt', 'args', 'output_encode']
     let config[opt] = quickrun#expand(config[opt])
+  endfor
+  for opt in ['output_filetype']
+    let config[opt] = config[opt]
   endfor
   return config
 endfunction

--- a/autoload/quickrun/outputter/buffer.vim
+++ b/autoload/quickrun/outputter/buffer.vim
@@ -22,7 +22,7 @@ endfunction
 
 function! s:outputter.output(data, session)
   let winnr = winnr()
-  call s:open_result_window(self.config.split)
+  call s:open_result_window(self.config.split, a:session.config.output_filetype)
   if !self._append
     silent % delete _
     let self._append = 1
@@ -67,7 +67,7 @@ function! s:outputter.finish(session)
     return
   endif
 
-  call s:open_result_window(self.config.split)
+  call s:open_result_window(self.config.split, a:session.config.output_filetype)
   execute self._line
   silent normal! zt
   if !self.config.into
@@ -77,7 +77,7 @@ function! s:outputter.finish(session)
 endfunction
 
 
-function! s:open_result_window(sp)
+function! s:open_result_window(sp, ft)
   if !exists('s:bufnr')
     let s:bufnr = -1  " A number that doesn't exist.
   endif
@@ -87,7 +87,7 @@ function! s:open_result_window(sp)
     let s:bufnr = bufnr('%')
     nnoremap <buffer> q <C-w>c
     setlocal bufhidden=hide buftype=nofile noswapfile nobuflisted
-    setlocal filetype=quickrun
+    execute 'setlocal filetype=' . a:ft
   elseif bufwinnr(s:bufnr) != -1
     execute bufwinnr(s:bufnr) 'wincmd w'
   else


### PR DESCRIPTION
お忙しいところ失礼致します。

例えばquickrunで実行したRSpecの結果に色を付けたりするのに、みなさん、outputterを登録してそこでsyntaxを設定をしているようです。もしかすると、quickrunの結果が出力されるバッファのfiletype自体を変更できたらより便利かもしれないと思いました。

vimrcで

```
let g:quickrun_config['ruby.rspec']['output_filetype'] = 'quickrun-rspec'

```

というような設定をして、
.vim/syntax/quickrun-rspec.vim
でsyntaxの記述をするといったイメージです。

このCommitは試しにその実装をしてみたものです。

ソースをいじらなくても現在の機能でこうすれば良い、などありましたら教えていただけると嬉しいです。
