### PR TITLE
add the Dart support

### DIFF
--- a/autoload/quickrun.vim
+++ b/autoload/quickrun.vim
@@ -127,6 +127,20 @@ let g:quickrun#default_config = {
 \   'exec': 'call %s %a',
 \   'tempfile': '%{tempname()}.bat',
 \ },
+\ 'dart': {
+\   'type':
+\     executable('dart') ? 'dart/dart/checked':
+\   '',
+\ },
+\ 'dart/dart/checked': {
+\   'command': 'dart',
+\   'cmdopt': '--enable-type-checks',
+\   'tempfile': '%{tempname()}.dart',
+\ },
+\ 'dart/dart/production': {
+\   'command': 'dart',
+\   'tempfile': '%{tempname()}.dart',
+\ },
 \ 'erlang': {
 \   'command': 'escript',
 \ },


### PR DESCRIPTION
I'm testing the Dart language using Vim with the vim-quickrun. this commit add the Dart language support basically for the vim-quickrun.

note: in this time, we cannot use "\r" without set "au BufNewFile,BufRead *.dart setf dart" as the filetype manually in our .vimrc .

thank you.
