### PR TITLE
quickrun/errorformat のデフォルト値を &l:errorformat → &g:errorformat の順に適用

### DIFF
--- a/autoload/quickrun/outputter/quickfix.vim
+++ b/autoload/quickrun/outputter/quickfix.vim
@@ -10,9 +10,10 @@ let s:outputter.config = {
 \   'errorformat': '',
 \ }
 
+let s:outputter.init_buffered = s:outputter.init
 
 function! s:outputter.init(session)
-  call call(quickrun#outputter#buffered#new().init, [a:session], self)
+  call self.init_buffered(a:session)
   let self.config.errorformat
 \    = !empty(self.config.errorformat) ? self.config.errorformat
 \    : !empty(&l:errorformat)          ? &l:errorformat


### PR DESCRIPTION
quickfix/errorformat のデフォルト値を
&l:errorformat → &g:errorformat
の順に適用させるようにしてみました。
前者が空の場合は、後者を参照します。
これで &l:errorformat が空の場合も &g:errorformat が参照されるようになります。
