### PR TITLE
write each module as absolute names

### DIFF
--- a/doc/quickrun.jax
+++ b/doc/quickrun.jax
@@ -421,30 +421,30 @@ runner はプログラムを実行するモジュールです。
 デフォルトでは以下の runner が使えます。
 NOTE: "system" 以外は不安定な場合があります。
 
-- "system"				*quickrun-module-runner/system*
+- "runner/system"				*quickrun-module-runner/system*
   |system()| を使って実行します。これが既定値です。
 
-- "shell"				*quickrun-module-runner/shell*
+- "runner/shell"				*quickrun-module-runner/shell*
   |:!| を使って実行します。この runner は outputter を無視します。
   オプション ~
-  shellcmd		デフォルト: MS Windows の場合は 'silent !"%s" & pause'
+  runner/shell/shellcmd		デフォルト: MS Windows の場合は 'silent !"%s" & pause'
 				    それ以外は '!%s'
 	実行する Vim コマンドのテンプレートです。%s が exec オプションで生成さ
 	れたコマンドに置換されます。
 
-- "vimproc"				*quickrun-module-runner/vimproc*
+- "runner/vimproc"				*quickrun-module-runner/vimproc*
   {|vimproc| が必要}
   |vimproc| を使ってコマンドをバックグラウンドで実行します。実行の完了を
   |CursorHold| と |CursorHoldI| イベントを使って検査します。50 ミリ秒以内に実
   行が終了した場合は、即座に結果を表示します。
   オプション ~
-  sleep			デフォルト: 50
+  runner/vimproc/sleep			デフォルト: 50
 	実行直後に指定ミリ秒だけ待ちます。即座に終了するプログラムの場合、
 	'updatetime' による待機をする必要がなくなります。
-  updatetime		デフォルト: 0
+  runner/vimproc/updatetime		デフォルト: 0
 	一時的に 'updatetime' をこの値に変更します。0 の場合は変更しません。
 
-- "remote"				*quickrun-module-runner/remote*
+- "runner/remote"				*quickrun-module-runner/remote*
   {|+clientserver| が必要}
   コマンドをバックグラウンドで実行し、終了を |+clientserver| 機能を利用して通
   知し結果を表示します。
@@ -453,17 +453,17 @@ NOTE: "system" 以外は不安定な場合があります。
   バックグラウンドで実行するため、コマンドが無限ループや入力待ち等で終了しな
   い場合、Vim から制御することはできないので注意してください。
   オプション ~
-  vimproc		デフォルト: 0
+  runner/remote/vimproc		デフォルト: 0
 	可能ならば |vimproc| でコマンドを実行します。これにより、実行のキャン
 	セルが可能になります。
 
-- "python"				*quickrun-module-runner/python*
+- "runner/python"				*quickrun-module-runner/python*
   {|+python| が必要}
   |python| のスレッドを利用してコマンドを非同期実行します。
   警告: これは非常に不安定です。
   警告: X11 環境では使用しないでください。Vim がクラッシュします。
 
-- "vimscript"				*quickrun-module-runner/vimscript*
+- "runner/vimscript"				*quickrun-module-runner/vimscript*
   コマンドを Vim のコマンドとして実行します。
   |:redir| コマンドを含む Vim コマンドは実行できません。これは出力を得るために
   |:redir| を使っているためです。|:redir| はネストできません。
@@ -475,97 +475,97 @@ OUTPUTTER					*quickrun-module-outputter*
 outputter は結果の出力を行うモジュールです。
 デフォルトでは以下の outputter が使えます。
 
-- "buffer"				*quickrun-module-outputter/buffer*
+- "outputter/buffer"				*quickrun-module-outputter/buffer*
   出力専用バッファを開いてそこへ出力します。このバッファは同じものが再利用され
   ます。
   オプション ~
-  name			デフォルト: "[quickrun output]"
+  outputter/buffer/name			デフォルト: "[quickrun output]"
 	バッファ名です。
-  filetype		デフォルト: "quickrun"
+  outputter/buffer/filetype		デフォルト: "quickrun"
 	バッファに設定される 'filetype' の値です。
-  append		デフォルト: 0
+  outputter/buffer/append		デフォルト: 0
 	1 の場合は追記を行います。
-  split
+  outputter/buffer/split
 	デフォルト: '{winwidth(0) * 2 < winheight(0) * 5 ? "" : "vertical"}'
 	出力専用バッファを開く際の補助コマンドを指定します。バッファを開く際に
 	|:split| コマンドの前に挿入されます。
-  into			デフォルト: 0
+  outputter/buffer/into			デフォルト: 0
 	0 以外を指定すると、結果が出た際に出力専用バッファへカーソルを移動しま
 	す。
-  running_mark		デフォルト: ':-)'
+  outputter/buffer/running_mark		デフォルト: ':-)'
 	この値が空文字列でない場合、実行中にこの文字列が出力先に表示されます。
 	表示は実行完了後に削除されます。
-  close_on_empty	Default: 0
+  outputter/buffer/close_on_empty	Default: 0
 	終了時にバッファが空だった場合、自動的にバッファを閉じます。
 
   フック ~
   outputter_buffer_opened
 	出力バッファが開いた時。
 
-- "message"				*quickrun-module-outputter/message*
+- "outputter/message"				*quickrun-module-outputter/message*
   |messages| に出力します。
   オプション ~
-  log			デフォルト: 0
+  outputter/message/log			デフォルト: 0
 	1 の場合、出力を |message-history| に記録します。
 
-- "variable"				*quickrun-module-outputter/variable*
+- "outputter/variable"				*quickrun-module-outputter/variable*
   変数に対して出力します。環境変数やオプションに対しても出力可能です。
   オプション ~
-  name			デフォルト: ''
+  outputter/variable/name			デフォルト: ''
 	出力先の変数名です。空の場合はエラーになります。
-  append		デフォルト: 0
+  outputter/variable/append		デフォルト: 0
 	1 の場合は追記を行います。
 
-- "file"				*quickrun-module-outputter/file*
+- "outputter/file"				*quickrun-module-outputter/file*
   ファイルに対して出力します。
   オプション ~
-  name			デフォルト: ''
+  outputter/file/name			デフォルト: ''
 	出力先のファイル名です。空の場合はエラーになります。
-  append		デフォルト: 0
+  outputter/file/append		デフォルト: 0
 	1 の場合は追記を行います。
 
-- "quickfix"				*quickrun-module-outputter/quickfix*
+- "outputter/quickfix"				*quickrun-module-outputter/quickfix*
   |quickfix| へ出力します。
   オプション ~
-  errorformat		デフォルト: "&errorformat"
+  outputter/quickfix/errorformat		デフォルト: "&errorformat"
 	出力を解釈するための 'errorformat' オプションの値です。
 
-- "browser"				*quickrun-module-outputter/browser*
+- "outputter/browser"				*quickrun-module-outputter/browser*
   {|open-browser| が必要}
   |open-browser| を使って、結果をブラウザで開きます。
   オプション ~
-  name			デフォルト: tempname() . '.html'
+  outputter/browser/name			デフォルト: tempname() . '.html'
 	この outputter はまず結果をファイルに書き出し、そのファイルをブラウザ
 	で開きます。その際の出力先のファイル名です。
 	デフォルト値の |tempname()| は初回ロード時に 1 度だけ呼び出され、全体
 	で固定になります。
-  append		デフォルト: 0
+  outputter/browser/append		デフォルト: 0
 	1 の場合はファイルに対して追記を行います。
 
-- "buffered"				*quickrun-module-outputter/buffered*
+- "outputter/buffered"				*quickrun-module-outputter/buffered*
   出力をバッファリングして、最後に一度に出力します。
   オプション ~
-  {target}		デフォルト: ''
+  outputter/buffered/target		デフォルト: ''
 	実際の出力に使う outputter です。
 
-- "multi"				*quickrun-module-outputter/multi*
+- "outputter/multi"				*quickrun-module-outputter/multi*
   複数の outputter に対して同時に出力を行います。
   オプション ~
-  targets		デフォルト: []
+  outputter/multi/targets		デフォルト: []
 	実際の出力に使う outputter のリストです。
 
-- "error"				*quickrun-module-outputter/error*
+- "outputter/error"				*quickrun-module-outputter/error*
   実行が正常終了した場合とそうでない場合で outputter を変えます。終了コードが
   0 の場合を正常終了とします。ただし、runner によっては常に正常終了となってし
   まうことがあります。
   終了を待つため、出力はバッファリングされます。
   オプション ~
-  success		デフォルト: "null"
+  outputter/error/success		デフォルト: "null"
 	実行の成功時に使う outputter です。
-  error			デフォルト: "null"
+  outputter/error/error			デフォルト: "null"
 	実行の失敗時に使う outputter です。
 
-- "null"				*quickrun-module-outputter/null*
+- "outputter/null"				*quickrun-module-outputter/null*
   出力を行いません。
 
 
@@ -575,17 +575,17 @@ HOOK						*quickrun-module-hook*
 hook は特定のポイントで追加の処理を行うモジュールです。
 デフォルトでは以下の hook が使えます。
 
-- "cd"					*quickrun-module-hook/cd*
+- "hook/cd"					*quickrun-module-hook/cd*
   カレントディレクトリを変更して実行します。
   NOTE: この hook は開始時に Vim 内のカレントディレクトリを変更し、終了時に復
 	元しようとします。非同期実行を使っていると、予期しない結果になるかもし
 	れません。
   オプション ~
-  directory		デフォルト: ""
+  hook/cd/directory		デフォルト: ""
 	変更先のディレクトリです。空文字列の場合は何もしません。
 	この値は |quickrun-exec-format| のように展開されます。
 
-- "eval"				*quickrun-module-hook/eval*
+- "hook/eval"				*quickrun-module-hook/eval*
   テンプレートを使ってソースファイルの中身を変更します。例えば、
   ソースファイル: >
     1 + 2 * 3
@@ -595,38 +595,38 @@ hook は特定のポイントで追加の処理を行うモジュールです。
     print(1 + 2 * 3);
 < になります。
   オプション ~
-  template		デフォルト: ""
+  hook/eval/template		デフォルト: ""
   テンプレート文字列です。テンプレート内の "%s" が元のソースファイルに置き変え
   られます。テンプレート内で "%" を使う場合は "%%" と書きます。
 
-- "output_encode"			*quickrun-module-hook/output_encode*
+- "hook/output_encode"			*quickrun-module-hook/output_encode*
   出力の文字コードを変換します。
   オプション ~
-  encoding		デフォルト: "&fileencoding"
+  hook/output_encode/encoding		デフォルト: "&fileencoding"
 	"from:to" の形式で指定します。":to" は省略できます。その場合、
 	"from:&encoding" と解釈されます。
 
-- "shebang"				*quickrun-module-hook/shebang*
+- "hook/shebang"				*quickrun-module-hook/shebang*
   ソースコードの先頭の #! を探し、その後続を command オプション
   (|quickrun-option-command|) として扱います。同時に、exec オプション
   (|quickrun-option-exec|) 内の "%c" を "%C" に変換します。
 
-- "sweep"				*quickrun-module-hook/sweep*
+- "hook/sweep"				*quickrun-module-hook/sweep*
   終了時に一時ファイルを削除します。
   オプション ~
-  files			デフォルト: []
+  hook/sweep/files			デフォルト: []
 	削除するファイルのリストです。この値は |quickrun-exec-format| のように
 	展開されます。エスケープを避けるために大文字を指定してください。
 
-- "time"				*quickrun-module-hook/time*
+- "hook/time"				*quickrun-module-hook/time*
   実行時間を計測し、最後に出力します。
   NOTE: 時間には quickrun.vim 自体のオーバーヘッドも含まれています。正確な時間
 	を期待しないでください。
   オプション ~
-  format		デフォルト: "\n*** time: %g ***"
+  hook/time/format		デフォルト: "\n*** time: %g ***"
 	出力する文字列の書式です。|printf()| に渡されます。第2引数には計測時間
 	が |Float| で渡されます。
-  dest			デフォルト: ""
+  hook/time/dest			デフォルト: ""
 	出力先の outputter です。空の場合はセッションの outputter へ出力しま
 	す。
 

--- a/doc/quickrun.txt
+++ b/doc/quickrun.txt
@@ -432,30 +432,30 @@ RUNNER						*quickrun-module-runner*
 Runner is a module to run a program.  The following runners are available by
 default.  NOTE: Everything except for "system" can be unstable.
 
-- "system"				*quickrun-module-runner/system*
+- "runner/system"				*quickrun-module-runner/system*
   Runs by |system()|.  This is the default.
 
-- "shell"				*quickrun-module-runner/shell*
+- "runner/shell"				*quickrun-module-runner/shell*
   Runs by |:!|.  This ignores given outputter.
   Option ~
-  shellcmd		Default: 'silent !"%s" & pause' for MS Windows
+  runner/shell/shellcmd		Default: 'silent !"%s" & pause' for MS Windows
 				    Otherwise '!%s'
 	The template of the Vim command to run.  This replaces %s to the
 	command given in exec option.
 
-- "vimproc"				*quickrun-module-runner/vimproc*
+- "runner/vimproc"				*quickrun-module-runner/vimproc*
   {Requirement: |vimproc|}
   Runs by |vimproc| at background.  This checks if the process completed with
   using |CursorHold| |CursorHoldI| events.  If the process completed within 50
   millisecond, it shows the result immediately.
   Option ~
-  sleep			Default: 50
+  runner/vimproc/sleep			Default: 50
 	Waits specified times in millisecond.  This is useful to avoid polling
 	by 'updatetime' when program will stop immediately.
-  updatetime		Default: 0
+  runner/vimproc/updatetime		Default: 0
 	Changes 'updatetime' to the value temporary.  Stays same if this is 0.
 
-- "remote"				*quickrun-module-runner/remote*
+- "runner/remote"				*quickrun-module-runner/remote*
   {Requirement: |+clientserver|}
   Runs in background and fetches the result by |+clientserver| feature.
   This requires |v:servername| to be set.  If Vim doesn't, run it with
@@ -464,17 +464,17 @@ default.  NOTE: Everything except for "system" can be unstable.
   Note that Vim cannot control the process when it doesn't terminate due to
   infinite loop or to wait for input since it runs in background.
   Option ~
-  vimproc		Default: 0
+  runner/remote/vimproc		Default: 0
 	Runs by |vimproc| if it's available.  You can cancel the process after
 	it ran.
 
-- "python"				*quickrun-module-runner/python*
+- "runner/python"				*quickrun-module-runner/python*
   {Requirement: |+python|}
   Runs by |python| thread asynchronously.
   WARNING: This is absolutely unstable.
   WARNING: Don't use this on X11.  Vim crashes.
 
-- "vimscript"				*quickrun-module-runner/vimscript*
+- "runner/vimscript"				*quickrun-module-runner/vimscript*
   Runs commands as Vim commands.
   Vim command that contains |:redir| command can not run.  This gets the
   output of vim script by |:redir| command.  And, |:redir| can not nest.
@@ -486,96 +486,96 @@ OUTPUTTER					*quickrun-module-outputter*
 Outputter is a module to output the result.  The following outputters are
 available by default.
 
-- "buffer"				*quickrun-module-outputter/buffer*
+- "outputter/buffer"				*quickrun-module-outputter/buffer*
   quickrun opens output buffer and displays to the output buffer.  If output
   buffer already exists, quickrun uses it.
   Option ~
-  name			Default: "[quickrun output]"
+  outputter/buffer/name			Default: "[quickrun output]"
 	The buffer name.
-  filetype		Default: "quickrun"
+  outputter/buffer/filetype		Default: "quickrun"
 	Sets this value to 'filetype' of the buffer.
-  append		Default: 0
+  outputter/buffer/append		Default: 0
 	Appends if it's 1.
-  split
+  outputter/buffer/split
 	Default: '{winwidth(0) * 2 < winheight(0) * 5 ? "" : "vertical"}'
 
 	Specifies a sub-command to open a buffer for the output.  |quickrun|
 	inserts this before |:split| command when it opens a buffer.
-  into			Default: 0
+  outputter/buffer/into			Default: 0
 	Moves cursor to the output buffer if this isn't 0.
-  running_mark		Default: ':-)'
+  outputter/buffer/running_mark		Default: ':-)'
 	If this value is not an empty string, |quickrun| displays this string
 	to output buffer while it's running.
-  close_on_empty	Default: 0
+  outputter/buffer/close_on_empty	Default: 0
 	Automatically close outputter buffer if empty.
 
   Hook ~
   outputter_buffer_opened
 	When the output buffer is opened.
 
-- "message"				*quickrun-module-outputter/message*
+- "outputter/message"				*quickrun-module-outputter/message*
   Outputs on |messages|.
   Option ~
-  log			Default: 0
+  outputter/message/log			Default: 0
 	Outputs on |message-history| is it's 1.
 
-- "variable"				*quickrun-module-outputter/variable*
+- "outputter/variable"				*quickrun-module-outputter/variable*
   Outputs on a variable.  You also can let it output on an environment
   variable or an option.
   Option ~
-  name			Default: ''
+  outputter/variable/name			Default: ''
 	The name of the variable to output.  Causes an error if it's empty.
-  append		Default: 0
+  outputter/variable/append		Default: 0
 	Appends if it's 1.
 
-- "file"				*quickrun-module-outputter/file*
+- "outputter/file"				*quickrun-module-outputter/file*
   Outputs on a file.
   Option ~
-  name			Default: ''
+  outputter/file/name			Default: ''
 	The file name where to output.  Causea an error if it's empty.
-  append		Default: 0
+  outputter/file/append		Default: 0
 	Appends if it's 1.
 
-- "quickfix"				*quickrun-module-outputter/quickfix*
+- "outputter/quickfix"				*quickrun-module-outputter/quickfix*
   Outputs on |quickfix|.
   Option ~
-  errorformat		Default: "&errorformat"
+  outputter/quickfix/errorformat		Default: "&errorformat"
 	'errorformat' option to parse the output.
 
-- "browser"				*quickrun-module-outputter/browser*
+- "outputter/browser"				*quickrun-module-outputter/browser*
   {Requires |open-browser|}
   Opens the output on browser, using |open-browser|.
   Option ~
-  name			Default: tempname() . '.html'
+  outputter/browser/name			Default: tempname() . '.html'
 	The name of the filename; outputs the result on a file first then open
 	the file on your browser.  The default value, |tempname()|, is called
 	only at once and the same result will be used since the second time.
-  append		Default: 0
+  outputter/browser/append		Default: 0
 	Appends if it's 1.
 
-- "buffered"				*quickrun-module-outputter/buffered*
+- "outputter/buffered"				*quickrun-module-outputter/buffered*
   Buffers the output, and shows the whole result at once finally.
   Option ~
-  target		Default: ''
+  outputter/buffered/target		Default: ''
 	The outputter to show the result.
 
-- "multi"				*quickrun-module-outputter/multi*
+- "outputter/multi"				*quickrun-module-outputter/multi*
   Outputs multiple outputters at the same time.
   Option ~
-  targets		Default: []
+  outputter/multi/targets		Default: []
 	A list of outputters to output.
 
-- "error"				*quickrun-module-outputter/error*
+- "outputter/error"				*quickrun-module-outputter/error*
   Switches where to output based on the exit status; 0 means success.  Note
   that some runners only can give success.
   This buffers because this waits the process terminates.
   Option ~
-  success		Default: "null"
+  outputter/error/success		Default: "null"
 	The outputter when it succeeded.
-  error			Default: "null"
+  outputter/error/error			Default: "null"
 	The outputter when it failed.
 
-- "null"				*quickrun-module-outputter/null*
+- "outputter/null"				*quickrun-module-outputter/null*
   No outputs.
 
 
@@ -585,17 +585,17 @@ HOOK						*quickrun-module-hook*
 Hook is a module to do additional process in specific points.  The following
 hooks are available by default.
 
-- "cd"					*quickrun-module-hook/cd*
+- "hook/cd"					*quickrun-module-hook/cd*
   Executes on specified directory.
   NOTE: This hook changes the current directory, and tries to restore it when
   finished.  An unexpected result may be brought when asynchronous execution
   is being used.
   Option ~
-  directory		Default: ""
+  hook/cd/directory		Default: ""
 	Directory to change.  Does nothing if this is an empty string.
 	This value is expanded by |quickrun-exec-format|.
 
-- "eval"				*quickrun-module-hook/eval*
+- "hook/eval"				*quickrun-module-hook/eval*
   Changes the contents of source file by a template.  For example:
   source file: >
     1 + 2 * 3
@@ -604,38 +604,38 @@ hooks are available by default.
 < In this case, the source file actually used is: >
     print(1 + 2 * 3);
 < Option ~
-  template		Default: ""
+  hook/eval/template		Default: ""
   A string of template.  "%s" is replaced by original source file.
   This rule is same as |printf()|.
 
-- "output_encode"			*quickrun-module-hook/output_encode*
+- "hook/output_encode"			*quickrun-module-hook/output_encode*
   Converts encoding of the output.
   Option ~
-  encoding		Default: "&fileencoding"
+  hook/output_encode/encoding		Default: "&fileencoding"
 	Specifies in the form of "from:to".  ":to" is omitable.
 	In this case, it is interpreted as "from:&encoding".
 
-- "shebang"				*quickrun-module-hook/shebang*
+- "hook/shebang"				*quickrun-module-hook/shebang*
   Searches "#!" in the head of source file, and treats the following of it as
   command option(|quickrun-option-command|).  At the same time, converts "%c"
   in exec option(|quickrun-option-exec|) into "%C".
 
-- "sweep"				*quickrun-module-hook/sweep*
+- "hook/sweep"				*quickrun-module-hook/sweep*
   Sweeps the temporary files at the end of session.
   Option ~
-  files			Default: []
+  hook/sweep/files			Default: []
 	A list of files to remove.  This value is expanded by
 	|quickrun-exec-format|.  Please use upper case to avoid escaping.
 
-- "time"				*quickrun-module-hook/time*
+- "hook/time"				*quickrun-module-hook/time*
   Measures the execution time and outputs to the end.
   NOTE: The time includes the overhead of quickrun.vim.  Don't expect exact
 	time.
   Option ~
-  format		Default: "\n*** time: %g ***"
+  hook/time/format		Default: "\n*** time: %g ***"
 	Format of output string.  This is passed to |printf()|.
 	Measured time is passed to the 2nd argument by |Float|.
-  dest			Default: ""
+  hook/time/dest			Default: ""
 	An outputter for outputting a result.  If this is empty, outputs to
 	the outputter of the session.
 


### PR DESCRIPTION
https://twitter.com/tyru/status/280019852331188225

> let g:quickrun_config['_'] = {'split': 'vertical rightbelow'} そういや_って_になったんだっけと思って変えてみてもダメだった。なんだろ。 

https://twitter.com/thinca/status/280148654017363968

> @tyru {'outputter/buffer/split': 'vertical rightbelow'} 

https://twitter.com/tyru/status/280171408154300416

> @thinca あーなるほど。splitとしか書かれてなかったんで、そう繋げるんですね。帰ったら試します。 

この時のやり取りで思ったんですが、こんな風に書いてくれてたら見やすかったかなーという書き方に修正してみました。どうでしょうか。

(あと細かいですが日本語版と英語版で`outputter/buffered/target`の書き方が違かったので修正してあります)
