### PR TITLE
v:version check does not work in 7.x.1-202

### DIFF
--- a/autoload/quickrun/runner/remote.vim
+++ b/autoload/quickrun/runner/remote.vim
@@ -70,6 +70,7 @@ function! s:runner.run(commands, input, session)
   else
     if s:is_win
       if 703 <= v:version && has('patch203')
+      \ || 703 < v:version
         silent! execute '!start /b' script
       else
         silent! execute '!start /min' script


### PR DESCRIPTION
このバージョンの判定方法は7.x.1-202(`x >= 4`)で正しく動かないです。
