### PR TITLE
無名バッファで空出力になるコマンドを実行するとエラーになる。

### DIFF
--- a/autoload/quickrun/outputter/buffer.vim
+++ b/autoload/quickrun/outputter/buffer.vim
@@ -71,7 +71,7 @@ function! s:outputter.finish(session)
   silent normal! zt
   let is_closed = 0
   if self.config.close_on_empty && line('$') == 1 && getline(1) =~ '^\s*$'
-    quit
+    silent quit!
     let is_closed = 1
   endif
   if !is_closed && !self.config.into


### PR DESCRIPTION
無名バッファで空出力になるコマンドを実行するとエラーになりますので、修正しました。

空出力になるコマンド： 例えば、filetype=rubyの状態で、`(1).instance_of? Fixnum`のバッファでQuickRunするとか。

**エラー内容**

>   Error detected while processing function quickrun#command..quickrun#run..99..102..150..146:  
>  line    9:  
>  E37: No write since last change (add ! to override)                          
