### PR TITLE
Add outputter/quickfix/open_cmd.

### DIFF
--- a/autoload/quickrun/outputter/quickfix.vim
+++ b/autoload/quickrun/outputter/quickfix.vim
@@ -8,6 +8,7 @@ set cpo&vim
 let s:outputter = quickrun#outputter#buffered#new()
 let s:outputter.config = {
 \   'errorformat': '',
+\   'open_cmd': 'cwindow',
 \ }
 
 let s:outputter.init_buffered = s:outputter.init
@@ -26,7 +27,7 @@ function! s:outputter.finish(session)
     let errorformat = &g:errorformat
     let &g:errorformat = self.config.errorformat
     cgetexpr self._result
-    cwindow
+    execute self.config.open_cmd
     for winnr in range(1, winnr('$'))
       if getwinvar(winnr, '&buftype') ==# 'quickfix'
         call setwinvar(winnr, 'quickfix_title', 'quickrun: ' .


### PR DESCRIPTION
outputter/quickfix/open_cmd を追加しました。
quickfix の開き方が設定出来ます。
このオプションを使用することで

``` vim
" 認識されたエラーがない場合でも quickfix を開く
:WatchdogsRun -outputter/quickfix/open_cmd "copen"

" quickfix は開かない
" unite-quickfix 等、quickfix 以外で出力したい場合に有効
:WatchdogsRun -outputter/quickfix/open_cmd ""
```

のような使い方ができます。
また、これは『quickfix を開かないように設定できる』ので、[この問題](https://twitter.com/aereal/status/362764789052739584)を回避することもできます。
