### PR TITLE
prompt for filetype if type was not specified and &filetype is not set

### DIFF
--- a/autoload/quickrun.vim
+++ b/autoload/quickrun.vim
@@ -1043,6 +1043,18 @@ function! s:build_config(config)
       call extend(config, new_config, 'keep')
     endif
   endfor
+
+  if config.type ==# ''
+    if empty(&filetype)
+      let l:ft=input('quickrun: filetype is not set, enter it here: ')
+      if !empty(l:ft)
+        exec 'set filetype='.l:ft
+        "try again
+        return s:build_config(a:config)
+      endif
+    endif
+  endif
+
   return config
 endfunction
 

--- a/autoload/quickrun/module.vim
+++ b/autoload/quickrun/module.vim
@@ -28,7 +28,7 @@ endfunction
 " Template of runner.  {{{2
 let s:templates.runner = deepcopy(s:module)
 function! s:templates.runner.run(commands, input, session)
-  throw 'quickrun: A runner should implements run()'
+  throw 'quickrun: A runner must implement run()'
 endfunction
 function! s:templates.runner.shellescape(str)
   return shellescape(a:str)
@@ -39,7 +39,7 @@ let s:templates.outputter = deepcopy(s:module)
 function! s:templates.outputter.start(session)
 endfunction
 function! s:templates.outputter.output(data, session)
-  throw 'quickrun: An outputter should implements output()'
+  throw 'quickrun: An outputter must implement output()'
 endfunction
 function! s:templates.outputter.finish(session)
 endfunction


### PR DESCRIPTION
I often use `:QuickRun` for an unsaved buffer, and this saves the extra step of having to remember to `:set ft=foo`. If `:QuickRun foo` is used, this won't interfere.
