### PR TITLE
Fix TypeScript

### DIFF
--- a/autoload/quickrun.vim
+++ b/autoload/quickrun.vim
@@ -417,7 +417,7 @@ let g:quickrun#default_config = {
 \ },
 \ 'typescript': {
 \   'command': 'tsc',
-\   'cmdopt': '--exec',
+\   'exec': ['%c --target es5 --module commonjs %o %s', 'node %s:r.js'],
 \   'tempfile': '%{tempname()}.ts',
 \ },
 \ 'vim': {


### PR DESCRIPTION
tscからexecオプションが削除されたので、
コンパイル後にnodeで実行するようにしました
