### PR TITLE
Specify the class file output directory

### DIFF
--- a/autoload/quickrun.vim
+++ b/autoload/quickrun.vim
@@ -242,7 +242,7 @@ let g:quickrun#default_config = {
 \ },
 \ 'io': {},
 \ 'java': {
-\   'exec': ['javac %o %s', '%c %s:t:r %a'],
+\   'exec': ['javac %o -d %s:p:h %s', '%c -cp %s:p:h %s:t:r %a'],
 \   'hook/output_encode/encoding': '&termencoding',
 \   'hook/sweep/files': '%S:p:r.class',
 \ },


### PR DESCRIPTION
``` java
public class Hello {
  public static void main(String[] args) {
    System.out.println("hello");
  }
}
// :QuickRun<CR>
// -> Error: Could not find or load main class Hello
```

Change to specify the directory that contains the class file explicitly.
