### PR TITLE
fixed doc of runner/process_manager/load

### DIFF
--- a/doc/quickrun.jax
+++ b/doc/quickrun.jax
@@ -460,8 +460,8 @@ NOTE: "system" 以外は不安定な場合があります。
   オプション ~
   runner/process_manager/load			デフォルト: "load %s"
 	起動した外部コマンドのstdinの書き込む、編集中ファイルを読み込み実行さ
-	せるための書式を指定します。%sは|quickrun-exec-format|のように、ソース
-	ファイル名に置換されます。たとえばこの値が"(load \"%s\")"で編集中ファ
+	せるための書式を指定します。%sまたは%Sは|quickrun-exec-format|のように、ソース
+	ファイル名に置換されます。たとえばこの値が"(load \"%S\")"で編集中ファ
 	イル名が"/home/ujihisa/a.clj"ならば、|quickrun|はcommandオプションによ
 	って起動されたプロセスに対し"(load \"/home/ujihisa/a.clj\")\n"という文
 	字列を書き込みます。

--- a/doc/quickrun.txt
+++ b/doc/quickrun.txt
@@ -472,8 +472,8 @@ default.  NOTE: Everything except for "system" can be unstable.
   runner/process_manager/load			Default: "load %s"
 	Specifies a code with placeholder to write to the stdin of an external
 	command to load and run the file you are editing. |quickrun| will
-	replace %s with the source file like |quickrun-exec-format| does. For
-	example if the value is "(load \"%s\")" and the current file you are
+	replace %s and %S with the source file like |quickrun-exec-format| does. For
+	example if the value is "(load \"%S\")" and the current file you are
 	editing is "/home/ujihisa/a.clj", |quickrun| writes
 	"(load \"/home/ujihisa/a.clj\")\n" to the process it ran based on
 	command option.


### PR DESCRIPTION
>   ファイル名に置換されます。たとえばこの値が"(load \"%S\")"で編集中ファ
>   イル名が"/home/ujihisa/a.clj"ならば、|quickrun|はcommandオプションによ
>   って起動されたプロセスに対し"(load \"/home/ujihisa/a.clj\")\n"という文

と、ありますが、`%s` では、`"(load \"'/home/ujihisa/a.clj'\")` というようにシングルクオートで囲まれた結果に置換されましたので、`%S` に修正しました。
