### PR TITLE
process_manager clojure support bugfix: avoid infinite loop when the prompt is corrupted

### DIFF
--- a/autoload/quickrun.vim
+++ b/autoload/quickrun.vim
@@ -72,9 +72,10 @@ let g:quickrun#default_config = {
 \ },
 \ 'clojure/process_manager': {
 \   'command': 'clojure-1.6',
+\   'cmdopt': '-e ''(clojure.main/repl :prompt #(print "\nquickrun/pm=> "))''',
 \   'runner': 'process_manager',
 \   'runner/process_manager/load': '(load-file "%S")',
-\   'runner/process_manager/prompt': 'user=> ',
+\   'runner/process_manager/prompt': 'quickrun/pm=> ',
 \ },
 \ 'coffee': {},
 \ 'cpp': {


### PR DESCRIPTION
ClojureのREPLのプロンプトはデフォルトで"user=> "で、このまま使っていました。が、以下の２つの問題がありました。
- `(print "\nuser=> ")`などするとそちらが終端と認識されて本物が認識されない
- "user=> "と同じ行の手前に何か文字列があると終端探知されずquickrunがいつまでも非同期に待ち続ける

後者が特に致命的で、かなり容易に再現できてしまいます。例: `(map inc "hi")` (これは"("をstdout出力して例外をstderrに出力するのだが、"("のstderrが後にくるため、最後の行が"(user=> "となり、終端検知に失敗する。

というわけで、このpullreqでプロンプトを"\nquickrun/pm=> "に変更しました。これで問題2を回避、かつ問題1の回避率を高めました。
