### PR TITLE
Improvement: when the process has died you had to trigger quickrun again...

### DIFF
--- a/autoload/quickrun/runner/process_manager.vim
+++ b/autoload/quickrun/runner/process_manager.vim
@@ -64,8 +64,9 @@ function! s:runner.run(commands, input, session)
     return 0
   elseif t ==# 'inactive'
     call s:P.kill(type)
-    call a:session.output('!!!process is inactive. try again.!!!')
-    return 0
+    call g:quickrun#V.Vim.Message.warn('process is inactive. Restarting...')
+    call a:session.finish()
+    return a:session.run()
   elseif t ==# 'timedout' || t ==# 'preparing'
     let key = a:session.continue()
     augroup plugin-quickrun-process-manager


### PR DESCRIPTION
コミットメッセージにあるとおりですが、これまでは
1. 一度runner/process_managerでquickrunする (初回なので遅いけどまあ仕方ない)
2. なんらかの事情でそのプロセスが死ぬ (psしてkillすることで簡単に再現可能)
3. 次runner/process_managerでquickrunするとエラーがでてもっかいquickrunすることを要求される (えー)
4. runner/process_managerでquickrunする (実質初回なので遅いけどまあ仕方ない)

という感じだったのが、このpullreqで
1. 一度runner/process_managerでquickrunする (初回なので遅いけどまあ仕方ない)
2. なんらかの事情でそのプロセスが死ぬ (psしてkillすることで簡単に再現可能)
3. 次runner/process_managerでquickrunすると勝手にプロセス起動しなおしてくれる (実質初回なので遅いけどまあ仕方ない)

という風になって便利になりました。
