### PR TITLE
Update swift/apple config

### DIFF
--- a/autoload/quickrun.vim
+++ b/autoload/quickrun.vim
@@ -445,9 +445,7 @@ let g:quickrun#default_config = {
 \ },
 \ 'swift/apple': {
 \   'command': 'xcrun',
-\   'exec': ['%c swift %s', '%s:p:r %a'],
-\   'tempfile': '%{tempname()}.swift',
-\   'hook/sweep/files': '%S:p:r',
+\   'exec': ['%c swift %s'],
 \ },
 \ 'typescript': {
 \   'command': 'tsc',


### PR DESCRIPTION
Xcode6-beta5 以降では `swift filename` でファイルを実行できるので、`exec` だけにしました。
