### PR TITLE
Add tempfile config for nim

### DIFF
--- a/autoload/quickrun.vim
+++ b/autoload/quickrun.vim
@@ -360,7 +360,7 @@ let g:quickrun#default_config = {
 \ 'markdown/markdown_py': {
 \   'command': 'markdown_py',
 \ },
-\ 'nimrod': {
+\ 'nim': {
 \   'cmdopt': 'compile --run',
 \   'hook/sweep/files': '%S:p:r',
 \ },

--- a/autoload/quickrun.vim
+++ b/autoload/quickrun.vim
@@ -363,6 +363,7 @@ let g:quickrun#default_config = {
 \ 'nim': {
 \   'cmdopt': 'compile --run --verbosity:0',
 \   'hook/sweep/files': '%S:p:r',
+\   'tempfile': '%{substitute(tempname(), ''/\(\d\+\)$'', ''nim\1'', '''')}.nim'
 \ },
 \ 'ocaml': {},
 \ 'perl': {

--- a/autoload/quickrun.vim
+++ b/autoload/quickrun.vim
@@ -361,7 +361,7 @@ let g:quickrun#default_config = {
 \   'command': 'markdown_py',
 \ },
 \ 'nim': {
-\   'cmdopt': 'compile --run',
+\   'cmdopt': 'compile --run --verbosity:0',
 \   'hook/sweep/files': '%S:p:r',
 \ },
 \ 'ocaml': {},


### PR DESCRIPTION
nimの一時ファイル実行がエラーになっていたのでデフォルトの設定にtempfileを追加しました。

Nimのファイルは数字始まりNG で拡張子 .nim が必要なのですが、自分の環境（Ubuntu 14.04, vim 7.4.580）ではtempname()が返すファイル名が数字のみのため実行できませんでした。
一時ファイル名の前後を変更するようにして対応しました。

しばらく自分で使った限りでは問題なかったのですが、他の環境（Windows等）では試せていません。
他の環境で問題があるかもしれないので（ないとは思っているのですが）、別のPRにさせていただきました。
ご確認よろしくお願いいたします。