### PR TITLE
Fix command for kotlin. Option -jar is no longer exists.

### DIFF
--- a/autoload/quickrun.vim
+++ b/autoload/quickrun.vim
@@ -312,10 +312,10 @@ let g:quickrun#default_config = {
 \ },
 \ 'kotlin': {
 \   'exec': [
-\     'kotlinc-jvm %s -jar %s:p:r.jar',
-\     'java -Xbootclasspath/a:%%{fnamemodify(' .
-\       'g:quickrun#V.System.Filepath.which("kotlinc-jvm"), ":h")}' .
-\       '/../lib/kotlin-runtime.jar -jar %s:p:r.jar'
+\     'kotlinc-jvm %s -d %s:p:r.jar',
+\     'java -Xbootclasspath/a:%{shellescape(fnamemodify(' .
+\       'fnamemodify(g:quickrun#V.System.Filepath.which("kotlinc-jvm"), ":h") . "/../lib/kotlin-runtime.jar", ":p"))}' .
+\       ' -jar %s:p:r.jar'
 \   ],
 \   'tempfile': '%{tempname()}.kt',
 \   'hook/sweep/files': ['%S:p:r.jar'],


### PR DESCRIPTION
`-jar` オプションは `-d` に名前変更になった様なので修正しました。
あと `C:\Program Files` でも動く様にしてあります。