### PR TITLE
Add read_timout option to runner/vimproc

### DIFF
--- a/autoload/quickrun/runner/vimproc.vim
+++ b/autoload/quickrun/runner/vimproc.vim
@@ -16,7 +16,7 @@ let s:runner = {
 \     'read_timeout': 65535,
 \   }
 \ }
-let s:bufsize = 65535
+let s:bufsize = -1
 
 function! s:runner.validate() abort
   if globpath(&runtimepath, 'autoload/vimproc.vim') ==# ''


### PR DESCRIPTION
`runner/vimproc` を介して重い処理を実行した時に、
vimproc の `s:runner.run()` は `stdout` と `stderr` の 2度 read_timeout を迎えることになります。
現在、vimproc ではデフォルトの read_timeout は 100ms に設定されているため、
この時間以内に処理が完了しない場合は必ず 200ms 待つことになります。

重い処理を実行するとあらかじめわかっている場合のために
オプションとして read_timeout を指定できるようにするのはいかがでしょうか。

なお、初期値には 65535 と大きな値を指定していますが、
vimproc はデフォルト値より大きな値が指定された場合は無視しているので影響はありません。
(十分大きな値を指定しただけですので、特に意味はありません)