### PR TITLE
Added 'rust/cargo' config

### DIFF
--- a/autoload/quickrun.vim
+++ b/autoload/quickrun.vim
@@ -428,6 +428,10 @@ let g:quickrun#default_config = {
 \   'tempfile': '%{tempname()}.rs',
 \   'hook/sweep/files': '%S:p:r',
 \ },
+\ 'rust/cargo': {
+\   'command': 'cargo',
+\   'exec': '%c run %o',
+\ },
 \ 'scala': {
 \   'hook/output_encode/encoding': '&termencoding',
 \ },


### PR DESCRIPTION
rust の Cargo 用の設定を追加しました．

Cargo は rust に標準添付のビルドシステムで，コマンド一発でビルドおよび実行ができます．rust のプロジェクト内だとファイル単体でコンパイルできないことがほとんどのため，Cargo 経由で実行するのが便利なので設定してみました．