### PR TITLE
[TypeScript] Sweep compiled .js file

### DIFF
--- a/autoload/quickrun.vim
+++ b/autoload/quickrun.vim
@@ -482,6 +482,7 @@ let g:quickrun#default_config = {
 \   'command': 'tsc',
 \   'exec': ['%c --target es5 --module commonjs %o %s', 'node %s:r.js'],
 \   'tempfile': '%{tempname()}.ts',
+\   'hook/sweep/files': ['%S:p:r.js'],
 \ },
 \ 'vim': {
 \   'command': ':source',


### PR DESCRIPTION
実行した後にコンパイル済みの js ファイルが残ったままになっていたので削除するようにしました．