### PR TITLE
Add support for the fish shell (www.fishshell.com) 

### DIFF
--- a/autoload/quickrun.vim
+++ b/autoload/quickrun.vim
@@ -215,6 +215,9 @@ let g:quickrun#default_config = {
 \   'command': 'erb',
 \   'exec': '%c %o -T - %s %a',
 \ },
+\ 'fish': {
+\   'command': 'fish',
+\ },
 \ 'fortran': {
 \   'type': 'fortran/gfortran',
 \ },


### PR DESCRIPTION
Hi, 
I love your plugin. I use it to show the plugins of a shell. I use fish as a default shell, so I would like this option to be included. This commit should be everything one needs. Please merge it into master.