### PR TITLE
Fix dosbatch

### DIFF
--- a/autoload/quickrun.vim
+++ b/autoload/quickrun.vim
@@ -187,8 +187,9 @@ let g:quickrun#default_config = {
 \   'hook/sweep/files': ['%S:p:r'],
 \ },
 \ 'dosbatch': {
-\   'command': '',
-\   'exec': 'call %s %a',
+\   'command': 'cmd',
+\   'exec': '%c /c "call %s %a"',
+\   'hook/output_encode/encoding': 'cp932',
 \   'tempfile': '%{tempname()}.bat',
 \ },
 \ 'dart': {


### PR DESCRIPTION
vimprocを使った時にエラーが出たんで直しました。ついでにdosbatchはWin環境限定と思いますので、cp932で文字化け回避しています。