### PR TITLE
Add tmux config.

### DIFF
--- a/autoload/quickrun.vim
+++ b/autoload/quickrun.vim
@@ -497,6 +497,10 @@ let g:quickrun#default_config = {
 \   'command': 'xcrun',
 \   'exec': ['%c swift %s'],
 \ },
+\ 'tmux': {
+\   'command': 'tmux',
+\   'exec': ['%c source-file %s:p'],
+\ },
 \ 'typescript': {
 \   'command': 'tsc',
 \   'exec': ['%c --target es5 --module commonjs %o %s', 'node %s:r.js'],


### PR DESCRIPTION
`tmux` quickrun config extracted from @rhysd [`.vimrc`](https://github.com/rhysd/dotfiles/blob/master/vimrc#L2262-L2266) file, if accepted I can safely remove this line from my `.tmux.conf`

```tmux
bind r source-file ~/.tmux.conf \; display "Reloaded ~/.tmux.conf"
```
