### PR TITLE
Changed evaluation and expansion order for exec command.

### DIFF
--- a/autoload/quickrun.vim
+++ b/autoload/quickrun.vim
@@ -611,7 +611,7 @@ function! s:Session.setup() abort
     call self.invoke_hook('module_loaded')
 
     let commands = copy(self.config.exec)
-    call filter(map(commands, 'self.build_command(quickrun#expand(v:val))'),
+    call filter(map(commands, 'self.build_command(v:val)'),
     \           'v:val =~# "\\S"')
     let self.commands = commands
   catch /^quickrun:/
@@ -727,7 +727,7 @@ function! s:Session.build_command(tmpl) abort
     endif
 
     let symbol = rest[1]
-    let value = get(rule, tolower(symbol), '')
+    let value = get(rule, tolower(symbol), '%' . symbol)
 
     if symbol ==? 'c' && value ==# ''
       throw 'quickrun: "command" option is empty.'
@@ -751,7 +751,8 @@ function! s:Session.build_command(tmpl) abort
     endif
     let result .= value
   endwhile
-  return substitute(result, '[\r\n]\+', ' ', 'g')
+  let result = substitute(result, '[\r\n]\+', ' ', 'g')
+  return quickrun#expand(result)
 endfunction
 
 function! s:Session.tempname(...) abort


### PR DESCRIPTION
いつも便利に使わせて頂いております。
最近、C/C++の構文チェックに本プラグインを用いた[vim-watchdogs](https://github.com/osyo-manga/vim-watchdogs)を使用しているのですが、includeパスなどが増えるとg:quickrun_configにいちいち設定を追加する必要があるのが手間でした。

そこでcmakeなどのツールがビルド実行時のコマンドをcompile_command.jsonファイルに吐く機能を利用して、構文チェック時に走らせるコンパイルコマンドをこのファイルから読み込ませる事にしました。

compile_command.jsonは以下の様な形式です。

```
[
    {
        "command": "c++ -c -g -I./include -o obj/a.o a.c", 
        "directory": "/Users/kota65535/test", 
        "file": "/Users/kota65535/test/a.c"
    },
    {
        ...
```

1. compile_command.jsonを読み込み、編集中のファイル名をキーにコマンドを取得する関数を作成
2. g:quickrun_config['wachdogs/gcc'].execに上記関数をevalで渡す

でできそうなので、以下のようにvimrcに書いてみました。

```
let g:quickrun_config['watchdogs_checker/gcc'] = {
          \ 'command' : 'gcc',
          \ 'exec' : ['%{GetCompileCommand(%s)} -fsyntax-only'],
          \ }

function! GetCompileCommand(srcfile)
   /// srcfileのパスを元にコマンドを返す
   ...
   return compile_command
endfunction

```

しかし問題が一点ありました。
`%{GetCompileCommand(%s)} `のevalの評価が先に行われてしまい、`%s`の展開はその後なので、うまく`GetCompileCommand(srcfile)`にソースファイルのパス情報を渡せなかったのです。そこで、`%s`の展開を先に行い、evalの評価をその後に行うように変更することで上手く行きました。

逆に、現在の評価順序で無ければ正しく動作しない設定になっているユーザーもいると思いますので、個別に選択可能にするのが良いのかもしれません。