### PR TITLE
Bugfix: concproc ignores output rarely

### DIFF
--- a/autoload/vital/_quickrun.vim
+++ b/autoload/vital/_quickrun.vim
@@ -1,16 +1,28 @@
 let s:self_version = expand('<sfile>:t:r')
 let s:self_file = expand('<sfile>')
-
-" Note: The extra argument to globpath() was added in Patch 7.2.051.
-let s:globpath_third_arg = v:version > 702 || v:version == 702 && has('patch51')
+let s:base_dir = expand('<sfile>:h')
 
 let s:loaded = {}
 let s:cache_module_path = {}
 let s:cache_sid = {}
 
-let s:_vital_files_cache_runtimepath = ''
-let s:_vital_files_cache = []
 let s:_unify_path_cache = {}
+
+function! s:plugin_name() abort
+  return s:self_version[1 :]
+endfunction
+
+function! s:vital_files() abort
+  if !exists('s:vital_files')
+    let s:vital_files =
+    \   map(
+    \     s:plugin_name() ==# '_latest__'
+    \       ? s:_global_vital_files()
+    \       : s:_self_vital_files(),
+    \     'fnamemodify(v:val, ":p:gs?[\\\\/]?/?")')
+  endif
+  return copy(s:vital_files)
+endfunction
 
 function! s:import(name, ...) abort
   let target = {}
@@ -67,6 +79,7 @@ function! s:unload() abort
   let s:loaded = {}
   let s:cache_sid = {}
   let s:cache_module_path = {}
+  unlet! s:vital_files
 endfunction
 
 function! s:exists(name) abort
@@ -74,33 +87,9 @@ function! s:exists(name) abort
 endfunction
 
 function! s:search(pattern) abort
-  let paths = s:_vital_files(a:pattern)
+  let paths = s:_extract_files(a:pattern, s:vital_files())
   let modules = sort(map(paths, 's:_file2module(v:val)'))
   return s:_uniq(modules)
-endfunction
-
-function! s:expand_modules(entry, all) abort
-  if type(a:entry) == type([])
-    let candidates = s:_concat(map(copy(a:entry), 's:search(v:val)'))
-    if empty(candidates)
-      throw printf('vital: Any of module %s is not found', string(a:entry))
-    endif
-    if eval(join(map(copy(candidates), 'has_key(a:all, v:val)'), '+'))
-      let modules = []
-    else
-      let modules = [candidates[0]]
-    endif
-  else
-    let modules = s:search(a:entry)
-    if empty(modules)
-      throw printf('vital: Module %s is not found', a:entry)
-    endif
-  endif
-  call filter(modules, '!has_key(a:all, v:val)')
-  for module in modules
-    let a:all[module] = 1
-  endfor
-  return modules
 endfunction
 
 function! s:_import(name) abort
@@ -134,10 +123,8 @@ function! s:_get_module_path(name) abort
   if s:_is_absolute_path(a:name) && filereadable(a:name)
     return a:name
   endif
-  if a:name ==# ''
-    let paths = [s:self_file]
-  elseif a:name =~# '\v^\u\w*%(\.\u\w*)*$'
-    let paths = s:_vital_files(a:name)
+  if a:name =~# '\v^\u\w*%(\.\u\w*)*$'
+    let paths = s:_extract_files(a:name, s:vital_files())
   else
     throw 'vital: Invalid module name: ' . a:name
   endif
@@ -154,8 +141,8 @@ function! s:_get_sid_by_script(path) abort
   endif
 
   let path = s:_unify_path(a:path)
-  for line in filter(split(s:_redir('scriptnames'), "\n"),
-  \                  'stridx(v:val, s:self_version) > 0')
+  let p = 'stridx(v:val, s:self_version) > 0 || stridx(v:val, "__latest__") > 0'
+  for line in filter(split(s:_redir('scriptnames'), "\n"), p)
     let list = matchlist(line, '^\s*\(\d\+\):\s\+\(.\+\)\s*$')
     if !empty(list) && s:_unify_path(list[2]) ==# path
       let s:cache_sid[a:path] = list[1] - 0
@@ -191,28 +178,21 @@ else
   endfunction
 endif
 
-if s:globpath_third_arg
-  function! s:_runtime_files(path) abort
-    return split(globpath(&runtimepath, a:path, 1), "\n")
-  endfunction
-else
-  function! s:_runtime_files(path) abort
-    return split(globpath(&runtimepath, a:path), "\n")
-  endfunction
-endif
+function! s:_self_vital_files() abort
+  let base = s:base_dir . '/*/**/*.vim'
+  return split(glob(base, 1), "\n")
+endfunction
 
-function! s:_vital_files(pattern) abort
-  if s:_vital_files_cache_runtimepath !=# &runtimepath
-    let path = printf('autoload/vital/%s/**/*.vim', s:self_version)
-    let s:_vital_files_cache = s:_runtime_files(path)
-    let mod = ':p:gs?[\\/]\+?/?'
-    call map(s:_vital_files_cache, 'fnamemodify(v:val, mod)')
-    let s:_vital_files_cache_runtimepath = &runtimepath
-  endif
-  let target = substitute(a:pattern, '\.', '/', 'g')
-  let target = substitute(target, '\*', '[^/]*', 'g')
-  let regexp = printf('autoload/vital/%s/%s.vim', s:self_version, target)
-  return filter(copy(s:_vital_files_cache), 'v:val =~# regexp')
+function! s:_global_vital_files() abort
+  let pattern = 'autoload/vital/__latest__/**/*.vim'
+  return split(globpath(&runtimepath, pattern, 1), "\n")
+endfunction
+
+function! s:_extract_files(pattern, files) abort
+  let tr = {'.': '/', '*': '[^/]*', '**': '.*'}
+  let target = substitute(a:pattern, '\.\|\*\*\?', '\=tr[submatch(0)]', 'g')
+  let regexp = printf('autoload/vital/[^/]\+/%s.vim$', target)
+  return filter(a:files, 'v:val =~# regexp')
 endfunction
 
 " Copy from System.Filepath
@@ -241,10 +221,17 @@ function! s:_build_module(sid) abort
     call module._vital_created(module)
   endif
   let export_module = filter(copy(module), 'v:key =~# "^\\a"')
+  " Cache module before calling module.vital_debug() to avoid cyclic
+  " dependences but remove the cache if module._vital_loaded() fails.
   let s:loaded[a:sid] = get(g:, 'vital_debug', 0) ? module : export_module
   if has_key(module, '_vital_loaded')
-    let V = vital#{s:self_version}#new()
-    call module._vital_loaded(V)
+    try
+      let V = vital#{s:self_version}#new()
+      call module._vital_loaded(V)
+    catch
+      unlet s:loaded[a:sid]
+      throw 'vital: fail to call ._vital_loaded(): ' . v:exception
+    endtry
   endif
   return copy(s:loaded[a:sid])
 endfunction
@@ -286,14 +273,6 @@ else
   endfunction
 endif
 
-function! s:_concat(lists) abort
-  let result_list = []
-  for list in a:lists
-    let result_list += list
-  endfor
-  return result_list
-endfunction
-
 function! s:_redir(cmd) abort
   let [save_verbose, save_verbosefile] = [&verbose, &verbosefile]
   set verbose=0 verbosefile=
@@ -305,5 +284,6 @@ function! s:_redir(cmd) abort
 endfunction
 
 function! vital#{s:self_version}#new() abort
-  return s:_import('')
+  let sid = s:_get_sid_by_script(s:self_file)
+  return s:_build_module(sid)
 endfunction

--- a/autoload/vital/_quickrun/ConcurrentProcess.vim
+++ b/autoload/vital/_quickrun/ConcurrentProcess.vim
@@ -167,7 +167,7 @@ function! s:tick(label) abort
     call s:tick(a:label)
   else
     " must not happen
-    throw "ConcurrentProcess: must not happen"
+    throw 'ConcurrentProcess: must not happen'
   endif
 endfunction
 
@@ -175,6 +175,7 @@ endfunction
 function! s:consume_all_blocking(label, varname, timeout_sec) abort
   let start = reltime()
   while 1
+    call s:tick(a:label)
     if s:is_done(a:label, a:varname)
       return s:consume(a:label, a:varname) + [0] " 0 as 'Did not timed out'
     elseif reltime(start)[0] >= a:timeout_sec
@@ -197,11 +198,9 @@ function! s:consume(label, varname) abort
 endfunction
 
 function! s:is_done(label, rname) abort
-  call s:tick(a:label)
-
   let reads = filter(
         \ copy(s:_process_info[a:label].queries),
-        \ 'v:val[0] ==# "*read*" || v:val[0] ==# "*read-all*"')
+        \ "v:val[0] ==# '*read*' || v:val[0] ==# '*read-all*'")
   return s:L.all(
         \ printf('v:val[1] !=# %s', string(a:rname)),
         \ reads)
@@ -236,7 +235,7 @@ function! s:log_dump(label) abort
   for [stdin, stdout, stderr] in s:_process_info[a:label].logs
     echon stdin
     echon stdout
-    if stderr
+    if stderr !=# ''
       echon printf('!!!%s!!!', stderr)
     endif
   endfor

--- a/autoload/vital/_quickrun/Data/String.vim
+++ b/autoload/vital/_quickrun/Data/String.vim
@@ -59,7 +59,7 @@ function! s:common_head(strs) abort
   endif
   let strs = len == 2 ? a:strs : sort(copy(a:strs))
   let pat = substitute(strs[0], '.', '\="[" . escape(submatch(0), "^\\") . "]"', 'g')
-  return pat == '' ? '' : matchstr(strs[-1], '\C^\%[' . pat . ']')
+  return pat ==# '' ? '' : matchstr(strs[-1], '\C^\%[' . pat . ']')
 endfunction
 
 " Split to two elements of List. ([left, right])
@@ -208,7 +208,7 @@ function! s:nr2byte(nr) abort
 endfunction
 
 function! s:nr2enc_char(charcode) abort
-  if &encoding == 'utf-8'
+  if &encoding ==# 'utf-8'
     return nr2char(a:charcode)
   endif
   let char = s:nr2byte(a:charcode)
@@ -220,7 +220,7 @@ endfunction
 
 function! s:nr2hex(nr) abort
   let n = a:nr
-  let r = ""
+  let r = ''
   while n
     let r = '0123456789ABCDEF'[n % 16] . r
     let n = n / 16
@@ -371,7 +371,7 @@ function! s:split_by_displaywidth(expr, width, float, is_wrap) abort
 
   let text = ''
   while cs_index < len(cs)
-    if cs[cs_index] is "\n"
+    if cs[cs_index] is# "\n"
       let text = s:padding_by_displaywidth(text, a:width, a:float)
       let lines += [text]
       let text = ''
@@ -392,7 +392,7 @@ function! s:split_by_displaywidth(expr, width, float, is_wrap) abort
         if a:is_wrap
           if a:width < w
             if a:width < strdisplaywidth(cs[cs_index])
-              while get(cs, cs_index, "\n") isnot "\n"
+              while get(cs, cs_index, "\n") isnot# "\n"
                 let cs_index += 1
               endwhile
               continue
@@ -401,7 +401,7 @@ function! s:split_by_displaywidth(expr, width, float, is_wrap) abort
             endif
           endif
         else
-          while get(cs, cs_index, "\n") isnot "\n"
+          while get(cs, cs_index, "\n") isnot# "\n"
             let cs_index += 1
           endwhile
           continue

--- a/autoload/vital/_quickrun/Prelude.vim
+++ b/autoload/vital/_quickrun/Prelude.vim
@@ -27,7 +27,7 @@ let [
 \   s:__TYPE_DICT,
 \   s:__TYPE_FLOAT] = [
       \   type(3),
-      \   type(""),
+      \   type(''),
       \   type(function('tr')),
       \   type([]),
       \   type({}),
@@ -69,7 +69,7 @@ function! s:is_dict(Value) abort
 endfunction
 
 function! s:truncate_skipping(str, max, footer_width, separator) abort
-  call s:_warn_deprecated("truncate_skipping", "Data.String.truncate_skipping")
+  call s:_warn_deprecated('truncate_skipping', 'Data.String.truncate_skipping')
 
   let width = s:wcswidth(a:str)
   if width <= a:max
@@ -87,7 +87,7 @@ function! s:truncate(str, width) abort
   " Original function is from mattn.
   " http://github.com/mattn/googlereader-vim/tree/master
 
-  call s:_warn_deprecated("truncate", "Data.String.truncate")
+  call s:_warn_deprecated('truncate', 'Data.String.truncate')
 
   if a:str =~# '^[\x00-\x7f]*$'
     return len(a:str) < a:width ?
@@ -109,7 +109,7 @@ function! s:truncate(str, width) abort
 endfunction
 
 function! s:strwidthpart(str, width) abort
-  call s:_warn_deprecated("strwidthpart", "Data.String.strwidthpart")
+  call s:_warn_deprecated('strwidthpart', 'Data.String.strwidthpart')
 
   if a:width <= 0
     return ''
@@ -125,7 +125,7 @@ function! s:strwidthpart(str, width) abort
   return ret
 endfunction
 function! s:strwidthpart_reverse(str, width) abort
-  call s:_warn_deprecated("strwidthpart_reverse", "Data.String.strwidthpart_reverse")
+  call s:_warn_deprecated('strwidthpart_reverse', 'Data.String.strwidthpart_reverse')
 
   if a:width <= 0
     return ''
@@ -144,12 +144,12 @@ endfunction
 if v:version >= 703
   " Use builtin function.
   function! s:wcswidth(str) abort
-    call s:_warn_deprecated("wcswidth", "Data.String.wcswidth")
+    call s:_warn_deprecated('wcswidth', 'Data.String.wcswidth')
     return strwidth(a:str)
   endfunction
 else
   function! s:wcswidth(str) abort
-    call s:_warn_deprecated("wcswidth", "Data.String.wcswidth")
+    call s:_warn_deprecated('wcswidth', 'Data.String.wcswidth')
 
     if a:str =~# '^[\x00-\x7f]*$'
       return strlen(a:str)
@@ -218,14 +218,14 @@ endfunction
 function! s:_warn_deprecated(name, alternative) abort
   try
     echohl Error
-    echomsg "Prelude." . a:name . " is deprecated!  Please use " . a:alternative . " instead."
+    echomsg 'Prelude.' . a:name . ' is deprecated!  Please use ' . a:alternative . ' instead.'
   finally
     echohl None
   endtry
 endfunction
 
 function! s:smart_execute_command(action, word) abort
-  execute a:action . ' ' . (a:word == '' ? '' : '`=a:word`')
+  execute a:action . ' ' . (a:word ==# '' ? '' : '`=a:word`')
 endfunction
 
 function! s:escape_file_searching(buffer_name) abort
@@ -243,7 +243,7 @@ endfunction
 
 function! s:getchar_safe(...) abort
   let c = s:input_helper('getchar', a:000)
-  return type(c) == type("") ? c : nr2char(c)
+  return type(c) == type('') ? c : nr2char(c)
 endfunction
 
 function! s:input_safe(...) abort
@@ -300,7 +300,7 @@ function! s:_path2project_directory_svn(path) abort
 
   let find_directory = s:escape_file_searching(search_directory)
   let d = finddir('.svn', find_directory . ';')
-  if d == ''
+  if d ==# ''
     return ''
   endif
 
@@ -310,9 +310,9 @@ function! s:_path2project_directory_svn(path) abort
   let parent_directory = s:path2directory(
         \ fnamemodify(directory, ':h'))
 
-  if parent_directory != ''
+  if parent_directory !=# ''
     let d = finddir('.svn', parent_directory . ';')
-    if d != ''
+    if d !=# ''
       let directory = s:_path2project_directory_svn(parent_directory)
     endif
   endif
@@ -325,7 +325,7 @@ function! s:_path2project_directory_others(vcs, path) abort
 
   let find_directory = s:escape_file_searching(search_directory)
   let d = finddir(vcs, find_directory . ';')
-  if d == ''
+  if d ==# ''
     return ''
   endif
   return fnamemodify(d, ':p:h:h')
@@ -345,25 +345,25 @@ function! s:path2project_directory(path, ...) abort
     else
       let directory = s:_path2project_directory_others(vcs, search_directory)
     endif
-    if directory != ''
+    if directory !=# ''
       break
     endif
   endfor
 
   " Search project file.
-  if directory == ''
+  if directory ==# ''
     for d in ['build.xml', 'prj.el', '.project', 'pom.xml', 'package.json',
           \ 'Makefile', 'configure', 'Rakefile', 'NAnt.build',
           \ 'P4CONFIG', 'tags', 'gtags']
       let d = findfile(d, s:escape_file_searching(search_directory) . ';')
-      if d != ''
+      if d !=# ''
         let directory = fnamemodify(d, ':p:h')
         break
       endif
     endfor
   endif
 
-  if directory == ''
+  if directory ==# ''
     " Search /src/ directory.
     let base = s:substitute_path_separator(search_directory)
     if base =~# '/src/'
@@ -371,7 +371,7 @@ function! s:path2project_directory(path, ...) abort
     endif
   endif
 
-  if directory == '' && !is_allow_empty
+  if directory ==# '' && !is_allow_empty
     " Use original path.
     let directory = search_directory
   endif

--- a/autoload/vital/_quickrun/Process.vim
+++ b/autoload/vital/_quickrun/Process.vim
@@ -19,23 +19,8 @@ let s:need_trans = v:version < 704 || (v:version == 704 && !has('patch122'))
 
 let s:TYPE_DICT = type({})
 let s:TYPE_LIST = type([])
-let s:TYPE_STRING = type("")
+let s:TYPE_STRING = type('')
 
-
-" Execute program in the background from Vim.
-" Return an empty string always.
-"
-" If a:expr is a List, shellescape() each argument.
-" If a:expr is a String, the arguments are passed as-is.
-"
-" Windows:
-" Using :!start , execute program without via cmd.exe.
-" Spawning 'expr' with 'noshellslash'
-" keep special characters from unwanted expansion.
-" (see :help shellescape())
-"
-" Unix:
-" using :! , execute program in the background by shell.
 function! s:spawn(expr, ...) abort
   let shellslash = 0
   if s:is_windows
@@ -70,11 +55,11 @@ endfunction
 
 " iconv() wrapper for safety.
 function! s:iconv(expr, from, to) abort
-  if a:from == '' || a:to == '' || a:from ==? a:to
+  if a:from ==# '' || a:to ==# '' || a:from ==? a:to
     return a:expr
   endif
   let result = iconv(a:expr, a:from, a:to)
-  return result != '' ? result : a:expr
+  return result !=# '' ? result : a:expr
 endfunction
 
 " Check vimproc.

--- a/autoload/vital/_quickrun/Vim/ViewTracer.vim
+++ b/autoload/vital/_quickrun/Vim/ViewTracer.vim
@@ -81,7 +81,7 @@ elseif has('patch-7.4.434')
   " This Bug is fixed in 7.4.834.
   function! s:_gettabdict(tabnr) abort
     let dict = gettabvar(a:tabnr, '')
-    return dict is '' ? gettabvar(a:tabnr, '') : dict
+    return dict is# '' ? gettabvar(a:tabnr, '') : dict
   endfunction
 else
   " Before Vim 7.4.434, gettabvar() doesn't return

--- a/autoload/vital/quickrun.vital
+++ b/autoload/vital/quickrun.vital
@@ -1,5 +1,5 @@
 quickrun
-536046c6f928ad6162141089d3d6e94f58101653
+15995127a79e856ee58eebb102a2ad61fbf7a61c
 
 Data.List
 System.File


### PR DESCRIPTION
vital.vimのconcprocにて、ごくまれに (具体的には最も再現しやすいコード例でも1/10くらいの発生率) `is_done()`直前に行われたstdout/stderr出力が無視されるいやらしいバグがありました。vitalの15995127a79e856ee58eebb102a2ad61fbf7a61cで修正したので、それをquickrunに反映。

scalaや(neoclojure未使用での)clojureのquickrunに良い影響があります。