### PR TITLE
fix the 'outputter/quickfix/into' option does not work

### DIFF
--- a/autoload/quickrun/outputter/quickfix.vim
+++ b/autoload/quickrun/outputter/quickfix.vim
@@ -30,10 +30,10 @@ function! s:outputter.finish(session) abort
   try
     let errorformat = &g:errorformat
     let &g:errorformat = self.config.errorformat
-    let current_window = s:VT.trace_window()
     call s:VT.jump(self._target_window)
     let result_list = self._apply_result(self._result)
     execute self.config.open_cmd
+    let current_window = s:VT.trace_window()
     if &buftype ==# 'quickfix'
       let w:quickfix_title = 'quickrun: ' .  join(a:session.commands, ' && ')
     endif
@@ -42,7 +42,7 @@ function! s:outputter.finish(session) abort
       call self._close_window()
     endif
     call s:VT.jump(self._target_window)
-    if !self.config.into
+    if self.config.into
       call s:VT.jump(current_window)
     endif
   finally


### PR DESCRIPTION
The line ` let current_window = s:VT.trace_window()` should be executed after the line `execute self.config.open_cmd' ` , otherwise the `current_window` will alway be identical with the `self._target_window`

Verified by using `QuickRun -outputter quickfix:into=1` and  `QuickRun -outputter quickfix:into=0` 