### PR TITLE
Support idris

### DIFF
--- a/autoload/quickrun.vim
+++ b/autoload/quickrun.vim
@@ -275,6 +275,12 @@ let g:quickrun#default_config = {
 \   'tempfile': '%{tempname()}.hs',
 \   'hook/sweep/files': ['%S:p:r', '%S:p:r.o', '%S:p:r.hi'],
 \ },
+\ 'idris': {
+\   'command': 'idris',
+\   'exec': ['%c %o %s --output %s:p:r', '%s:p:r %a'],
+\   'tempfile': '%{tempname()}.idr',
+\   'hook/sweep/files': ['%S:p:r', '%S:p:r.ibc'],
+\ },
 \ 'io': {},
 \ 'java': {
 \   'exec': ['javac %o -d %s:p:h %s', '%c -cp %s:p:h %s:t:r %a'],


### PR DESCRIPTION
idrisは依存型をとてもサポートした言語で、構文など色々Haskellに似ています :dog2:

- - -

以下は参考までに 👍 

- [Idris | A Language with Dependent Types](https://www.idris-lang.org/)
- [Getting Start](http://docs.idris-lang.org/en/latest/tutorial/starting.html)
- [Idrisが間もなくバージョン1.0に](https://www.infoq.com/jp/news/2017/01/idris-approaching-10)