### PR TITLE
Replace temporally filename to bufname in quickfix.

### DIFF
--- a/autoload/quickrun/outputter/loclist.vim
+++ b/autoload/quickrun/outputter/loclist.vim
@@ -13,6 +13,10 @@ function! s:outputter._apply_result(expr) abort
   return getloclist(0)
 endfunction
 
+function! s:outputter._apply_result_list(result_list) abort
+  call setloclist(0, a:result_list)
+endfunction
+
 function! s:outputter._close_window() abort
   lclose
 endfunction

--- a/autoload/quickrun/outputter/quickfix.vim
+++ b/autoload/quickrun/outputter/quickfix.vim
@@ -23,6 +23,7 @@ function! s:outputter.init(session) abort
 \    : !empty(&l:errorformat)          ? &l:errorformat
 \    : &g:errorformat
   let self._target_window = s:VT.trace_window()
+  let self._target_buf = bufnr('%')
 endfunction
 
 
@@ -59,11 +60,10 @@ function! s:outputter._fix_result_list(session, result_list) abort
     return 0
   endif
   let fixed = 0
-  let bufnr = bufnr('%')
   let loffset = region.first[0] - 1
   for row in a:result_list
     if bufname(row.bufnr) ==# srcfile
-      let row.bufnr = bufnr
+      let row.bufnr = self._target_buf
       let row.lnum += loffset
       let fixed = 1
     endif


### PR DESCRIPTION
If buffer is modified, the error list in quickfix points to the temporally file.
This PR will replace the temporally filename to bufname.
And fix lnum by region.

未保存状態で実行した場合 quickfix への出力はテンポラリファイルを示しているため、元のバッファを示すように修正します。また、リージョンを実行した場合は行番号を補正します。