### PR TITLE
Fix quickrun/hook/eval to expand config.tempfile

### DIFF
--- a/autoload/quickrun/hook/eval.vim
+++ b/autoload/quickrun/hook/eval.vim
@@ -21,7 +21,7 @@ endfunction
 function! s:hook.on_module_loaded(session, context) abort
   let src = join(readfile(a:session.config.srcfile, 'b'), "\n")
   let new_src = printf(self.config.template, src)
-  let srcfile = a:session.tempname()
+  let srcfile = a:session.tempname(quickrun#expand(a:session.config.tempfile))
   if writefile(split(new_src, "\n", 1), srcfile, 'b') == 0
     let a:session.config.srcfile = srcfile
   endif


### PR DESCRIPTION
現状、 hook/eval/template を利用した時、一時ファイル名として問答無用で `a:session.tempname()` が利用されています。

この `a:session.tempname()` は g:quickrun_config.[filetype].tempfile を全く気にしないので、特にここでファイルの拡張子を指定していてもそれが無視されてしまいます。これにより例えば C++ などでは出力先ファイル名とソースファイル名が同一になってしまい、正常に実行できなくなります。

対処法としては、 

1. Session.tempname 内で tempfile を展開するようにする。
1. 予め展開したものを `a:session.tempname()` に渡して登録させる (部分選択時の動作はこちら？) 。

のいずれかが考えられますが、影響範囲を考えてとりあえず 2 で対応してみました。
