### PR TITLE
Convert result fileformat.

### DIFF
--- a/autoload/quickrun/hook/output_encode.vim
+++ b/autoload/quickrun/hook/output_encode.vim
@@ -8,6 +8,7 @@ set cpo&vim
 let s:hook = {
 \   'config': {
 \     'encoding': '&fileencoding',
+\     'fileformat': 0,
 \   },
 \ }
 
@@ -19,12 +20,22 @@ function! s:hook.init(session) abort
   if len(enc) is 2 && enc[0] !=# '' && enc[1] !=# '' && enc[0] !=# enc[1]
     let [self._from, self._to] = enc
   else
+    let [self._from, self._to] = ['', '']
+  endif
+  if self._from ==# '' && !self.config.fileformat
     let self.config.enable = 0
   endif
 endfunction
 
 function! s:hook.on_output(session, context) abort
-  let a:context.data = iconv(a:context.data, self._from, self._to)
+  let data = a:context.data
+  if self._from !=# ''
+    let data = iconv(data, self._from, self._to)
+  endif
+  if self.config.fileformat
+    let data = substitute(data, '\r\n\?', '\n', 'g')
+  endif
+  let a:context.data = data
 endfunction
 
 function! quickrun#hook#output_encode#new() abort

--- a/doc/quickrun.jax
+++ b/doc/quickrun.jax
@@ -674,8 +674,9 @@ hook は特定のポイントで追加の処理を行うモジュールです。
   hook/output_encode/encoding		デフォルト: "&fileencoding"
 	"from:to" の形式で指定します。":to" は省略できます。その場合、
 	"from:&encoding" と解釈されます。
-  hook/output_encode/fileformat		デフォルト: 0
-	0 以外を指定すると、出力の改行を Unix 形式に変換します。
+  hook/output_encode/fileformat		デフォルト: ""
+	出力の改行を指定された形式に変換します。空文字列の場合は何もしません。
+	指定できる値は "unix"、"dos" または "mac" です。
 
 - "hook/shebang"			*quickrun-module-hook/shebang*
   ソースコードの先頭の #! を探し、その後続を command オプション

--- a/doc/quickrun.jax
+++ b/doc/quickrun.jax
@@ -669,11 +669,13 @@ hook は特定のポイントで追加の処理を行うモジュールです。
   られます。テンプレート内で "%" を使う場合は "%%" と書きます。
 
 - "hook/output_encode"			*quickrun-module-hook/output_encode*
-  出力の文字コードを変換します。
+  出力の文字コードと改行を変換します。
   オプション ~
   hook/output_encode/encoding		デフォルト: "&fileencoding"
 	"from:to" の形式で指定します。":to" は省略できます。その場合、
 	"from:&encoding" と解釈されます。
+  hook/output_encode/fileformat		デフォルト: 0
+	0 以外を指定すると、出力の改行を Unix 形式に変換します。
 
 - "hook/shebang"			*quickrun-module-hook/shebang*
   ソースコードの先頭の #! を探し、その後続を command オプション

--- a/doc/quickrun.txt
+++ b/doc/quickrun.txt
@@ -674,11 +674,13 @@ hooks are available by default.
   This rule is same as |printf()|.
 
 - "hook/output_encode"			*quickrun-module-hook/output_encode*
-  Converts encoding of the output.
+  Converts encoding and end-of-line of the output.
   Option ~
   hook/output_encode/encoding		Default: "&fileencoding"
 	Specifies in the form of "from:to".  ":to" is omittable.
 	In this case, it is interpreted as "from:&encoding".
+  hook/output_encode/fileformat		Default: 0
+	Convert end-of-line to Unix if this isn't 0.
 
 - "hook/shebang"				*quickrun-module-hook/shebang*
   Searches "#!" in the head of source file, and treats the following of it as

--- a/doc/quickrun.txt
+++ b/doc/quickrun.txt
@@ -679,8 +679,9 @@ hooks are available by default.
   hook/output_encode/encoding		Default: "&fileencoding"
 	Specifies in the form of "from:to".  ":to" is omittable.
 	In this case, it is interpreted as "from:&encoding".
-  hook/output_encode/fileformat		Default: 0
-	Convert end-of-line to Unix if this isn't 0.
+  hook/output_encode/fileformat		Default: ""
+	Convert end-of-line to gives setting if this isn't empty.
+	The value is "unix", "dos" or "mac".
 
 - "hook/shebang"				*quickrun-module-hook/shebang*
   Searches "#!" in the head of source file, and treats the following of it as


### PR DESCRIPTION
設定 `{'hook/output_encode/fileformat': 1}`  により、出力中の改行を正規化します。