### PR TITLE
Add option `runner/vimproc/pipe_status_index`.

### DIFF
--- a/autoload/quickrun/runner/vimproc.vim
+++ b/autoload/quickrun/runner/vimproc.vim
@@ -97,7 +97,11 @@ function! s:receive_vimproc_result(key, read_timeout, pipe_status_index) abort
   let status = vimproc.waitpid()[1]
   if has_key(vimproc, 'pipe_status')
     let session.pipe_status = map(copy(vimproc.pipe_status), 'v:val[1]')
-    let status = get(session.pipe_status, a:pipe_status_index, status)
+    if string(a:pipe_status_index) ==# string('pipefail')
+      let status = get(filter(copy(session.pipe_status), 'v:val'), -1, 0)
+    else
+      let status = get(session.pipe_status, a:pipe_status_index, status)
+    endif
   endif
   call session.finish(status)
   return 1

--- a/autoload/quickrun/runner/vimproc.vim
+++ b/autoload/quickrun/runner/vimproc.vim
@@ -19,9 +19,20 @@ let s:runner = {
 \ }
 let s:bufsize = -1
 
+let s:M = g:quickrun#V.import('Vim.Message')
+
 function! s:runner.validate() abort
   if globpath(&runtimepath, 'autoload/vimproc.vim') ==# ''
     throw 'Needs vimproc.'
+  endif
+endfunction
+
+function! s:runner.init(session) abort
+  if type(self.config.pipe_status_index) !=# type(0) &&
+  \  string(self.config.pipe_status_index) !=# string('pipefail')
+    call s:M.warn("Invalid value in `runner/vimproc/pipe_status_index`: "
+    \            .string(self.config.pipe_status_index))
+    let self.config.pipe_status_index = -1
   endif
 endfunction
 

--- a/autoload/quickrun/runner/vimproc.vim
+++ b/autoload/quickrun/runner/vimproc.vim
@@ -14,6 +14,7 @@ let s:runner = {
 \     'updatetime': 0,
 \     'sleep': 50,
 \     'read_timeout': 100,
+\     'pipe_status_index': -1,
 \   }
 \ }
 let s:bufsize = -1
@@ -36,13 +37,16 @@ function! s:runner.run(commands, input, session) abort
   if self.config.sleep
     execute 'sleep' self.config.sleep . 'm'
   endif
-  if s:receive_vimproc_result(key, self.config.read_timeout)
+  if s:receive_vimproc_result(key, self.config.read_timeout,
+  \                           self.config.pipe_status_index)
     return
   endif
   " Execution is continuing.
   augroup plugin-quickrun-runner-vimproc
     execute 'autocmd! CursorHold,CursorHoldI * call'
-    \       's:receive_vimproc_result(' . string(key) . ', ' . string(self.config.read_timeout) . ')'
+    \       's:receive_vimproc_result(' . string(key) . ','
+    \         string(self.config.read_timeout) . ','
+    \         string(self.config.pipe_status_index) . ')'
   augroup END
   let self._autocmd = 1
   if self.config.updatetime
@@ -65,7 +69,7 @@ function! s:runner.sweep() abort
 endfunction
 
 
-function! s:receive_vimproc_result(key, read_timeout) abort
+function! s:receive_vimproc_result(key, read_timeout, pipe_status_index) abort
   let session = quickrun#session(a:key)
 
   let vimproc = session._vimproc
@@ -90,8 +94,12 @@ function! s:receive_vimproc_result(key, read_timeout) abort
 
   call vimproc.stdout.close()
   call vimproc.stderr.close()
-  call vimproc.waitpid()
-  call session.finish(get(vimproc, 'status', 1))
+  let status = vimproc.waitpid()[1]
+  if has_key(vimproc, 'pipe_status')
+    let session.pipe_status = map(copy(vimproc.pipe_status), 'v:val[1]')
+    let status = get(session.pipe_status, a:pipe_status_index, status)
+  endif
+  call session.finish(status)
   return 1
 endfunction
 

--- a/doc/quickrun.jax
+++ b/doc/quickrun.jax
@@ -442,6 +442,13 @@ NOTE: "system" 以外は不安定な場合があります。
 	一時的に 'updatetime' をこの値に変更します。0 の場合は変更しません。
   runner/vimproc/read_timeout		デフォルト: 100
 	1 度の読み込みにかける時間(ミリ秒)です。
+  runner/vimproc/pipe_status_index	デフォルト: -1
+	コマンドがパイプを含む場合、|quickrun-session.exit_code| に設定される
+	終了コードを出力するサブコマンドをパイプ内の位置で指定します。先頭のコ
+	マンドは 0、最後のコマンドは -1 になります。
+	文字列 "pipefail" を指定すると、最後の 0 以外の終了コードが設定されま
+	す。全ての終了コードが 0 の場合は 0 が設定されます。
+
 
 - "runner/concurrent_process"	*quickrun-module-runner/concurrent_process*
   {|vimproc| が必要}

--- a/doc/quickrun.txt
+++ b/doc/quickrun.txt
@@ -451,6 +451,12 @@ default.  NOTE: Everything except for "system" can be unstable.
 	Changes 'updatetime' to the value temporary.  Stays same if this is 0.
   runner/vimproc/read_timeout		Default: 100
 	The time to read at one time. (milliseconds)
+  runner/vimproc/pipe_status_index	Default: -1
+	If the command contains a pipe, select the index of sub-command that
+	sets {exit-code} to |quickrun-session.exit_code|. The first command is 0
+	and the last command is -1.
+	If this value is the string "pipefail", the last non-zero {exit-code}
+	will be used. If all {exit-codes} are zero, 0 is used.
 
 - "runner/concurrent_process"	*quickrun-module-runner/concurrent_process*
   {Requirement: |vimproc|}


### PR DESCRIPTION
`runner/vimproc` でコマンドがパイプを含む場合、どの位置の終了コードを最終結果とするかを指定できるようにします。
設定名と値は bash または zsh の `$pipestatus` と `set -o pipefail` に由来します。

```vim
" cat, grep は無視して常に "%c" コマンドの終了コードを利用する。
let b:quickrun_config = {
\  "exec": "cat foo.txt | %c %o %s %a | grep bar",
\  "runner/vimproc/pipe_status_index": 1,
\}

" 全てのコマンドから、最後(最も右側)の 0 以外の終了コードを利用する。
" (全てのコマンドが成功(終了コード 0)した場合のみ 0 が返る。)
let b:quickrun_config = {
\  "exec": "preproc %s | %c %o %s %a | postproc",
\  "runner/vimproc/pipe_status_index": "pipefail",
\}
```

