### PR TITLE
typescript: Use ts-node if possible

### DIFF
--- a/autoload/quickrun.vim
+++ b/autoload/quickrun.vim
@@ -524,6 +524,7 @@ let g:quickrun#default_config = {
 \ },
 \ 'typescript/ts-node': {
 \   'command': 'ts-node',
+\   'cmdopt': '--compilerOptions ''{"target": "es2015"}''',
 \   'exec': '%c %o %s',
 \ },
 \ 'typescript/tsc': {

--- a/autoload/quickrun.vim
+++ b/autoload/quickrun.vim
@@ -519,6 +519,14 @@ let g:quickrun#default_config = {
 \   'exec': ['%c source-file %s:p'],
 \ },
 \ 'typescript': {
+\   'type': executable('ts-node') ? 'typescript/ts-node' :
+\           executable('tsc') ? 'typescript/tsc' : '',
+\ },
+\ 'typescript/ts-node': {
+\   'command': 'ts-node',
+\   'exec': '%c %o %s',
+\ },
+\ 'typescript/tsc': {
 \   'command': 'tsc',
 \   'exec': ['%c --target es5 --module commonjs %o %s', 'node %s:r.js'],
 \   'tempfile': '%{tempname()}.ts',


### PR DESCRIPTION
[ts-node](https://github.com/TypeStrong/ts-node) is a CLI tool like `node` command, but can run TypeScript code directly.

This PR makes vim-quickrun prefer `ts-node` to `tsc` because `ts-node` does not need to create a temporary file (compile code on the fly). If `ts-node` is not installed, this PR does not break previous behavior. It falls back into `tsc`.
