### PR TITLE
Add prolog config (prolog/swi, prolog/gnu)

### DIFF
--- a/autoload/quickrun.vim
+++ b/autoload/quickrun.vim
@@ -425,6 +425,20 @@ let g:quickrun#default_config = {
 \   'hook/sweep/files': ['%S:p:h/%S:p:h:t'],
 \   'hook/cd/directory': '%S:p:h',
 \ },
+\ 'prolog': {
+\   'type': executable('swipl') ? 'prolog/swi' :
+\           executable('gprolog') ? 'prolog/gnu' : '',
+\ },
+\ 'prolog/gnu': {
+\   'command': 'gprolog',
+\   'cmdopt': '--consult-file',
+\   'exec': '%c %o %s %a --query-goal halt',
+\ },
+\ 'prolog/swi': {
+\   'command': 'swipl',
+\   'cmdopt': '--quiet -s',
+\   'exec': '%c %o %s %a -g halt',
+\ },
 \ 'ps1': {
 \   'exec': '%c %o -File %s %a',
 \   'command': 'powershell.exe',


### PR DESCRIPTION
Prolog の処理系 SWI prolog と GNU prolog を追加しました。
テスト用に使ったスクリプトです。

```prolog
main :-
  write('hello'),nl,
  write('world'),nl,
  nl,
  write('prolog')
  % ,halt.    % halt がない場合もある場合も必ず終了するようにする
  .
:- initialization(main).
```

Prolog はスクリプトで `halt.` がなければ Prolog のプロンプト (REPL) が立ち上がるので、
それぞれ `-g` (SWI), `--query-goal` (GNU) で 終了するようにしています。

追記：
確認環境：Windows Subsystem Linux (Debian 9.5)