### PR TITLE
Fix Dart support

### DIFF
--- a/autoload/quickrun.vim
+++ b/autoload/quickrun.vim
@@ -192,7 +192,6 @@ let g:quickrun#default_config = {
 \ },
 \ 'dart/dart/checked': {
 \   'command': 'dart',
-\   'cmdopt': '--enable-type-checks',
 \   'tempfile': '%{tempname()}.dart',
 \ },
 \ 'dart/dart/production': {


### PR DESCRIPTION
Flag `--enable-type-checks` isn't supported anymore.