### PR TITLE
Fix typescript/deno config

### DIFF
--- a/autoload/quickrun.vim
+++ b/autoload/quickrun.vim
@@ -595,6 +595,7 @@ let g:quickrun#default_config = {
 \ 'typescript/deno' : {
 \   'command': 'deno',
 \   'cmdopt': '--no-check --allow-all --unstable',
+\   'tempfile': '%{tempname()}.ts',
 \   'exec': ['%c run %o %s'],
 \ },
 \ 'typescript/ts-node': {


### PR DESCRIPTION
実行対象の tempfile に拡張子 `.ts` がないと JavaScript として解釈されるようで、TypeScript 側の予約語等を使うとエラーになります。

Deno 1.9.2 (2021-04-28 時点の最新) で確認。