### PR TITLE
Add runner/{job,terminal}/env option

### DIFF
--- a/autoload/quickrun/runner/job.vim
+++ b/autoload/quickrun/runner/job.vim
@@ -6,6 +6,7 @@ let s:is_win = has('win32')
 let s:runner = {
 \   'config': {
 \     'pty': 0,
+\     'env': {},
 \     'interval': 0,
 \   }
 \ }
@@ -31,10 +32,10 @@ function s:runner.run(commands, input, session) abort
   \   'callback': self._job_cb,
   \   'close_cb': self._job_close_cb,
   \   'exit_cb': self._job_exit_cb,
+  \   'pty': self.config.pty,
+  \   'env': self.config.env,
   \ }
-  if has('patch-8.0.0744')
-    let options.pty = self.config.pty
-  endif
+
   if a:input ==# ''
     let options.in_io = 'null'
   else

--- a/autoload/quickrun/runner/terminal.vim
+++ b/autoload/quickrun/runner/terminal.vim
@@ -8,6 +8,7 @@ let s:runner = {
 \     'name': 'default',
 \     'opener': 'new',
 \     'into': 0,
+\     'env': {},
 \   },
 \ }
 
@@ -40,6 +41,7 @@ function s:runner.run(commands, input, session) abort
   \   'curwin': 1,
   \   'close_cb': self._job_close_cb,
   \   'exit_cb': self._job_exit_cb,
+  \   'env': self.config.env,
   \ }
 
   let self._key = a:session.continue()

--- a/doc/quickrun.jax
+++ b/doc/quickrun.jax
@@ -516,6 +516,8 @@ NOTE: "system" 以外は不安定な場合があります。
   オプション ~
   runner/job/pty			デフォルト: 0
 	|job_start()| に渡す pty の値を指定します。
+  runner/job/env			デフォルト: {}
+	|job_start()| に渡す環境変数の dict を指定します。
   runner/job/interval			デフォルト: 0
 	Vim 8.0.0036 以前は、job 機能は、10 秒毎に job の終了をチェックします
 	(|job-exit_cb|)。このオプションに 0 以外を設定すると、|timer| を
@@ -530,6 +532,8 @@ NOTE: "system" 以外は不安定な場合があります。
 	ターミナルウィンドウを開くための Ex コマンドです。
   runner/terminal/into			デフォルト: 0
 	0 以外を指定すると、開いたターミナルウィンドウに移動します。
+  runner/terminal/env			デフォルト: {}
+	|term_start()| に渡す環境変数の dict を指定します。
 
 - "runner/vimscript"			*quickrun-module-runner/vimscript*
   コマンドを Vim のコマンドとして実行します。

--- a/doc/quickrun.txt
+++ b/doc/quickrun.txt
@@ -527,6 +527,8 @@ default.  NOTE: Everything except for "system" can be unstable.
   Option ~
   runner/job/pty			Default: 0
 	Specifies a value of pty to pass to |job_start()|.
+  runner/job/env			Default: {}
+	Specifies a dict of environment variables to pass to |job_start()|.
   runner/job/interval			Default: 0
 	Before Vim 8.0.0036, job feature checks about every 10 seconds for
 	jobs that ended (|job-exit_cb|).
@@ -542,6 +544,8 @@ default.  NOTE: Everything except for "system" can be unstable.
 	An Ex command to open a terminal window.
   runner/terminal/into			Default: 0
 	Moves cursor to the terminal window if this isn't 0.
+  runner/terminal/env			Default: {}
+	Specifies a dict of environment variables to pass to |term_start()|.
 
 - "runner/vimscript"			*quickrun-module-runner/vimscript*
   Runs commands as Vim commands.


### PR DESCRIPTION
使用例:
デフォルトで色付け等のエスケープシーケンスが出力されるコマンド (~deno など~) があるので、環境変数 `NO_COLOR` をセットしてエスケープシーケンスを抑制する。
https://no-color.org