### PR TITLE
Fix fsharp to use dotnet fsi

### DIFF
--- a/autoload/quickrun.vim
+++ b/autoload/quickrun.vim
@@ -252,7 +252,7 @@ let g:quickrun#default_config = {
 \ 'fsharp/dotnet': {
 \   'exec': ['%c fsi %o %s'],
 \   'command': 'dotnet',
-\   'cmdopt': '--utf8output --codepage:65001',
+\   'cmdopt': '--nologo --utf8output --codepage:65001',
 \ },
 \ 'fsharp/mono': {
 \   'exec': ['%c %o --out:%s:p:r.exe %s', 'mono %s:p:r.exe %a'],

--- a/autoload/quickrun.vim
+++ b/autoload/quickrun.vim
@@ -245,8 +245,14 @@ let g:quickrun#default_config = {
 \   'hook/sweep/files': ['%S:p:r'],
 \ },
 \ 'fsharp': {
-\   'type': executable('fsharpc') ? 'fsharp/mono' :
+\   'type': executable('dotnet') ? 'fsharp/dotnet' :
+\           executable('fsharpc') ? 'fsharp/mono' :
 \           executable('fsc') ? 'fsharp/vs' : '',
+\ },
+\ 'fsharp/dotnet': {
+\   'exec': ['%c fsi %o %s'],
+\   'command': 'dotnet',
+\   'cmdopt': '--utf8output --codepage:65001',
 \ },
 \ 'fsharp/mono': {
 \   'exec': ['%c %o --out:%s:p:r.exe %s', 'mono %s:p:r.exe %a'],


### PR DESCRIPTION
### Describe the bug

Recently, F# is running on dotnet command. But vim-quickfix does not support it.

### Provide a minimal vimrc with less than 50 lines to reproduce
<!-- Paste a minimal vimrc below to reproduce problem. -->

```vim
Plug 'fsharp/vim-fsharp'
```

### How to reproduce the problem from Vim startup
<!-- Steps to reproduce the behavior. -->

No way to run.

### Expected behavior
<!-- A clear and concise description of what you expected to happen. -->

Works with dotnet fsi command.

### Actual behavior
<!-- A clear and concise description of what actual happened. -->

Does not work.

### Your environment

- OS: Windows 11 64bit
- Vim's version: Vim 8.2.4748
- Plugin's version: ac177bdf8198709b0ac9f31308e24d25f7ff22c7 


