### PR TITLE
Enable typescript/deno automatically if deno exists

### DIFF
--- a/autoload/quickrun.vim
+++ b/autoload/quickrun.vim
@@ -601,7 +601,8 @@ let g:quickrun#default_config = {
 \ },
 \ 'typescript': {
 \   'type': executable('ts-node') ? 'typescript/ts-node' :
-\           executable('tsc') ? 'typescript/tsc' : '',
+\           executable('tsc') ? 'typescript/tsc' :
+\           executable('deno') ? 'typescript/deno' : '',
 \ },
 \ 'typescript/deno' : {
 \   'command': 'deno',


### PR DESCRIPTION
Fix `typescript/deno` isn't enabled in default even if `deno` is installed.

