### PR TITLE
feat! remove deno unstable option

### DIFF
--- a/autoload/quickrun.vim
+++ b/autoload/quickrun.vim
@@ -606,7 +606,7 @@ let g:quickrun#default_config = {
 \ },
 \ 'typescript/deno' : {
 \   'command': 'deno',
-\   'cmdopt': '--no-check --allow-all --unstable',
+\   'cmdopt': '--no-check --allow-all',
 \   'tempfile': '%{tempname()}.ts',
 \   'exec': ['%c run %o %s'],
 \ },


### PR DESCRIPTION
## what happen

Currently (deno  v1.44.4) , the following warning is occurring.

The `--unstable` flag is deprecated and will be removed in Deno 2.0. Use granular `--unstable-*` flags instead.
Learn more at: https://docs.deno.com/runtime/manual/tools/unstable_flags

## background

I don't think it's realistic to write all the --unstable-* options.
And new options may be brake old deno.

## warnings

If you remove the --unstable option, some denos that were previously working will no longer work.
